### PR TITLE
refactor: simplify holdings pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,11 +16,11 @@ Downloads public ETF/index holdings and writes ticker lists for humans and Tradi
 Do not read the whole repo first. Start here:
 
 1. **User-facing shape**: `README.md` for outputs and install/run commands.
-2. **Config/flow**: `src/index_etfs/holdings.py`.
-   - `ETF_CONFIGS`: source URLs/providers.
-   - Provider loaders: `_load_ssga_excel`, `_load_ishares_csv`, `_load_nasdaq_json`.
-   - Cleanup: `_filter_and_clean`.
-   - Output: `_save_holdings`, `_tradingview_symbols`, `_watchlist_lines`.
+2. **Config/flow**:
+   - `src/index_etfs/catalog.py`: `ETF_CONFIGS`, expected counts, validation.
+   - `src/index_etfs/sources.py`: provider loaders and cleanup.
+   - `src/index_etfs/outputs.py`: ticker/watchlist/metadata writers.
+   - `src/index_etfs/holdings.py`: public API and CLI orchestration.
 3. **Tests for behavior**: `tests/test_holdings.py`.
 4. **CI/update behavior** only if needed: `.github/workflows/ci.yml`, `.github/workflows/data-refresh.yml`.
 5. **Generated data** only when changing data output: `tickers/*.txt`, `watchlists/*.txt`, and `metadata/*.json`.
@@ -28,7 +28,10 @@ Do not read the whole repo first. Start here:
 ## Layout
 
 ```text
-src/index_etfs/holdings.py   downloader, cleaners, writers, CLI entry point
+src/index_etfs/catalog.py    ETF config and count validation
+src/index_etfs/sources.py    downloader, provider parsers, cleaners
+src/index_etfs/outputs.py    ticker, watchlist, and metadata writers
+src/index_etfs/holdings.py   public API and CLI entry point
 tests/test_holdings.py       mocked unit tests; no network required
 tickers/*.txt                plain ticker outputs, one ticker per line
 watchlists/*.txt             TradingView outputs, ###Section headers + EXCHANGE:TICKER lines

--- a/src/index_etfs/catalog.py
+++ b/src/index_etfs/catalog.py
@@ -1,0 +1,64 @@
+"""ETF configuration and validation."""
+
+import math
+from dataclasses import dataclass
+from typing import Literal
+
+Provider = Literal["ssga", "ishares", "nasdaq"]
+
+MIN_EXPECTED_RATIO = 0.9
+
+
+@dataclass(frozen=True)
+class ETFConfig:
+    url: str
+    provider: Provider
+    watchlist_name: str
+    expected_count: int
+
+
+ETF_CONFIGS = {
+    "spy": ETFConfig(
+        url="https://www.ssga.com/us/en/individual/library-content/products/fund-data/etfs/us/holdings-daily-us-en-spy.xlsx",
+        provider="ssga",
+        watchlist_name="sp500",
+        expected_count=503,
+    ),
+    "mdy": ETFConfig(
+        url="https://www.ssga.com/us/en/individual/library-content/products/fund-data/etfs/us/holdings-daily-us-en-mdy.xlsx",
+        provider="ssga",
+        watchlist_name="sp400",
+        expected_count=400,
+    ),
+    "spsm": ETFConfig(
+        url="https://www.ssga.com/us/en/individual/library-content/products/fund-data/etfs/us/holdings-daily-us-en-spsm.xlsx",
+        provider="ssga",
+        watchlist_name="sp600",
+        expected_count=600,
+    ),
+    "qqq": ETFConfig(
+        url="https://api.nasdaq.com/api/quote/list-type/nasdaq100",
+        provider="nasdaq",
+        watchlist_name="nasdaq100",
+        expected_count=100,
+    ),
+    "iwm": ETFConfig(
+        url="https://www.blackrock.com/varnish-api/blk-one01-product-data/product-data/api/v1/get-fund-document?appType=PRODUCT_PAGE&appSubType=ISHARES&targetSite=us-ishares&locale=en_US&portfolioId=239710&userType=individual&component=holdings",
+        provider="ishares",
+        watchlist_name="russell2000",
+        expected_count=2000,
+    ),
+}
+
+
+def validate_count(symbol: str, count: int) -> None:
+    """Fail closed on empty or suspiciously small source data."""
+    if count == 0:
+        raise ValueError(f"{symbol.upper()} returned zero rows")
+
+    expected = ETF_CONFIGS[symbol].expected_count
+    minimum = math.ceil(expected * MIN_EXPECTED_RATIO)
+    if count < minimum:
+        raise ValueError(
+            f"{symbol.upper()} returned {count} rows; expected at least {minimum}"
+        )

--- a/src/index_etfs/holdings.py
+++ b/src/index_etfs/holdings.py
@@ -1,303 +1,19 @@
-"""📊 Extract ticker symbols from various index ETFs.
+"""📊 Extract ticker symbols from index ETFs."""
 
-This module downloads ETF/index holdings from public providers (SSGA, iShares, Nasdaq)
-and extracts just the ticker symbols (e.g., AAPL, MSFT, GOOGL).
-"""
-
-import io
-import json
-import math
-import urllib.request
-from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
-from typing import Literal
 
 import polars as pl
 
-
-Provider = Literal["ssga", "ishares", "nasdaq"]
-
-
-@dataclass(frozen=True)
-class ETFConfig:
-    url: str
-    provider: Provider
-    watchlist_name: str
-    expected_count: int
-
-
-# 🎯 ETF Configuration
-ETF_CONFIGS = {
-    "spy": ETFConfig(
-        url="https://www.ssga.com/us/en/individual/library-content/products/fund-data/etfs/us/holdings-daily-us-en-spy.xlsx",
-        provider="ssga",
-        watchlist_name="sp500",
-        expected_count=503,
-    ),
-    "mdy": ETFConfig(
-        url="https://www.ssga.com/us/en/individual/library-content/products/fund-data/etfs/us/holdings-daily-us-en-mdy.xlsx",
-        provider="ssga",
-        watchlist_name="sp400",
-        expected_count=400,
-    ),
-    "spsm": ETFConfig(
-        url="https://www.ssga.com/us/en/individual/library-content/products/fund-data/etfs/us/holdings-daily-us-en-spsm.xlsx",
-        provider="ssga",
-        watchlist_name="sp600",
-        expected_count=600,
-    ),
-    "qqq": ETFConfig(
-        url="https://api.nasdaq.com/api/quote/list-type/nasdaq100",
-        provider="nasdaq",
-        watchlist_name="nasdaq100",
-        expected_count=100,
-    ),
-    "iwm": ETFConfig(
-        url="https://www.blackrock.com/varnish-api/blk-one01-product-data/product-data/api/v1/get-fund-document?appType=PRODUCT_PAGE&appSubType=ISHARES&targetSite=us-ishares&locale=en_US&portfolioId=239710&userType=individual&component=holdings",
-        provider="ishares",
-        watchlist_name="russell2000",
-        expected_count=2000,
-    ),
-}
-
-FIREFOX_HEADERS = {
-    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0",
-    "Accept": "*/*",
-    "Accept-Language": "en-US,en;q=0.5",
-}
-
-TRADINGVIEW_SCAN_URL = "https://scanner.tradingview.com/america/scan"
-MIN_EXPECTED_RATIO = 0.9
-
-
-def _validate_count(symbol: str, count: int) -> None:
-    """Fail closed on empty or suspiciously small source data."""
-    if count == 0:
-        raise ValueError(f"{symbol.upper()} returned zero rows")
-
-    expected = ETF_CONFIGS[symbol].expected_count
-    minimum = math.ceil(expected * MIN_EXPECTED_RATIO)
-    if count < minimum:
-        raise ValueError(
-            f"{symbol.upper()} returned {count} rows; expected at least {minimum}"
-        )
-
-
-def _write_metadata(results: dict[str, int], output_dir: Path | None = None) -> None:
-    """Write latest generated counts and source URLs."""
-    if output_dir is None:
-        output_dir = Path.cwd()
-
-    metadata = {
-        "generated_at": datetime.now(UTC)
-        .replace(microsecond=0)
-        .isoformat()
-        .replace("+00:00", "Z"),
-        "watchlists": {
-            config.watchlist_name: {
-                "count": count,
-                "expected_count": config.expected_count,
-                "minimum_count": math.ceil(config.expected_count * MIN_EXPECTED_RATIO),
-                "source": symbol,
-                "source_url": config.url,
-            }
-            for symbol, count in results.items()
-            for config in [ETF_CONFIGS[symbol]]
-        },
-    }
-
-    metadata_dir = output_dir / "metadata"
-    metadata_dir.mkdir(parents=True, exist_ok=True)
-    (metadata_dir / "latest.json").write_text(json.dumps(metadata, indent=2) + "\n")
-
-
-def _read_url(url: str) -> io.BytesIO:
-    """Read a URL with browser-ish headers."""
-    request = urllib.request.Request(url, headers=FIREFOX_HEADERS)
-    with urllib.request.urlopen(request, timeout=30) as response:
-        return io.BytesIO(response.read())
-
-
-def _tradingview_symbols(tickers: list[str], chunk_size: int = 200) -> dict[str, tuple[str, str]]:
-    """Map tickers to TradingView symbols and sector-ish group names."""
-    symbols = {}
-    headers = FIREFOX_HEADERS | {
-        "Content-Type": "application/json",
-        "Origin": "https://www.tradingview.com",
-        "Referer": "https://www.tradingview.com/",
-    }
-
-    for start in range(0, len(tickers), chunk_size):
-        chunk = tickers[start : start + chunk_size]
-        payload = {
-            "filter": [{"left": "name", "operation": "in_range", "right": chunk}],
-            "columns": ["name", "sector", "industry"],
-            "markets": ["america"],
-        }
-        request = urllib.request.Request(
-            TRADINGVIEW_SCAN_URL,
-            data=json.dumps(payload).encode(),
-            headers=headers,
-        )
-        with urllib.request.urlopen(request, timeout=30) as response:
-            rows = json.load(response).get("data", [])
-
-        for row in rows:
-            data = row.get("d", [])
-            ticker = data[0] if data else None
-            symbol = row.get("s", "")
-            group = next((value for value in data[1:3] if value), "Other")
-            if ticker in chunk and ":" in symbol:
-                symbols.setdefault(ticker, (symbol, group))
-
-    return symbols
-
-
-def _watchlist_lines(tickers: list[str], symbols: dict[str, tuple[str, str]]) -> list[str]:
-    """Build TradingView watchlist lines grouped by ### headers."""
-    groups: dict[str, list[str]] = {}
-    for ticker in tickers:
-        symbol, group = symbols.get(ticker, (ticker, "Other"))
-        groups.setdefault(group, []).append(symbol)
-
-    return [line for group in sorted(groups) for line in (f"###{group}", *groups[group])]
-
-
-def _load_ssga_excel(url: str) -> pl.DataFrame:
-    """🏢 Load SSGA Excel format holdings data.
-
-    Args:
-        url: URL to the SSGA Excel file
-
-    Returns:
-        Polars DataFrame with holdings data
-    """
-    df_dict = pl.read_excel(_read_url(url), sheet_id=0, read_options={"header_row": 4})
-
-    # 🎲 Handle both dict and DataFrame returns
-    if isinstance(df_dict, dict):
-        df = list(df_dict.values())[0]
-    else:
-        df = df_dict
-
-    return df
-
-
-def _load_ishares_csv(url: str) -> pl.DataFrame:
-    """🏢 Load iShares CSV format holdings data.
-
-    Args:
-        url: URL to the iShares CSV file
-
-    Returns:
-        Polars DataFrame with holdings data
-    """
-    df = pl.read_csv(
-        _read_url(url),
-        skip_rows=9,
-        columns=["Ticker", "Name", "Weight (%)", "Market Currency"],
-        truncate_ragged_lines=True,
-    )
-    df = df.rename({"Weight (%)": "Weight"})
-    return df
-
-
-def _load_nasdaq_json(url: str) -> pl.DataFrame:
-    """🏢 Load Nasdaq-100 symbols from Nasdaq's public JSON endpoint."""
-    rows = json.load(_read_url(url)).get("data", {}).get("data", {}).get("rows")
-    if not rows:
-        raise ValueError("Nasdaq response did not contain any Nasdaq-100 rows")
-
-    tickers = [row["symbol"].strip().replace("/", ".") for row in rows if row.get("symbol")]
-    if not tickers:
-        raise ValueError("Nasdaq response did not contain any symbols")
-
-    return pl.DataFrame({"Ticker": tickers})
-
-
-def _filter_and_clean(df: pl.DataFrame, provider: str) -> pl.DataFrame:
-    """🧹 Filter and clean holdings data based on provider format.
-
-    Args:
-        df: Input DataFrame
-        provider: ETF provider name (ssga, ishares, nasdaq)
-
-    Returns:
-        Cleaned DataFrame with just Ticker column (uppercase symbols only)
-    """
-    # 🏃 Handle empty DataFrame early - just select Ticker column
-    if len(df) == 0:
-        return df.select("Ticker") if "Ticker" in df.columns else pl.DataFrame({"Ticker": []})
-
-    if provider in ("ssga", "ishares"):
-        currency_col = "Local Currency" if provider == "ssga" else "Market Currency"
-        df = df.filter((pl.col(currency_col) == "USD") & (pl.col("Ticker") != "-"))
-
-    # 🎯 Filter out null/empty tickers, special placeholders, get uppercase symbols only, sorted alphabetically
-    df = df.filter(
-        pl.col("Ticker").is_not_null()
-        & (pl.col("Ticker") != "")
-        & (pl.col("Ticker") != "-")
-        & ~pl.col("Ticker").str.contains("_", literal=True)  # Exclude CASH_USD and similar placeholders
-        & ~pl.col("Ticker").str.contains(" ", literal=True)  # Exclude warrants like "BBBY WS"
-    ).select("Ticker").sort("Ticker")
-    return df
-
-
-def _save_holdings(df: pl.DataFrame, symbol: str, output_dir: Path | None = None) -> None:
-    """💾 Save ticker symbols to a text file.
-
-    Args:
-        df: DataFrame containing ticker symbols
-        symbol: ETF symbol (used for filename)
-        output_dir: Optional output directory (defaults to current directory)
-    """
-    if output_dir is None:
-        output_dir = Path.cwd()
-
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    # 📝 Save as simple newline-separated list of tickers
-    tickers = df["Ticker"].to_list()
-    tickers_dir = output_dir / "tickers"
-    tickers_dir.mkdir(exist_ok=True)
-    (tickers_dir / f"{symbol}.txt").write_text("\n".join(tickers) + "\n")
-
-    config = ETF_CONFIGS.get(symbol)
-    if config is None:
-        return
-
-    watchlist_dir = output_dir / "watchlists"
-    watchlist_dir.mkdir(exist_ok=True)
-    symbols = _tradingview_symbols(tickers)
-    missing = [ticker for ticker in tickers if ticker not in symbols]
-    if missing:
-        print(f"⚠️  No TradingView metadata for {', '.join(missing)}")
-    (watchlist_dir / f"{config.watchlist_name}.txt").write_text(
-        "\n".join(_watchlist_lines(tickers, symbols)) + "\n"
-    )
+from .catalog import ETF_CONFIGS, validate_count
+from .outputs import save_holdings, write_metadata
+from .sources import filter_and_clean, load_holdings
 
 
 def get_etf_holdings(
     symbol: str,
     output_dir: Path | None = None,
 ) -> pl.DataFrame:
-    """📈 Get ticker symbols for a specific ETF.
-
-    This is the main function for downloading and extracting ticker symbols.
-    It handles different provider formats automatically.
-
-    Args:
-        symbol: ETF symbol (spy, mdy, spsm, qqq, iwm)
-        output_dir: Optional directory to save output file
-
-    Returns:
-        DataFrame with just the Ticker column (uppercase symbols, sorted alphabetically)
-
-    Raises:
-        ValueError: If the ETF symbol is not recognized
-    """
+    """Download, clean, save, and return holdings for one configured ETF."""
     symbol_lower = symbol.lower()
 
     if symbol_lower not in ETF_CONFIGS:
@@ -307,88 +23,51 @@ def get_etf_holdings(
         )
 
     config = ETF_CONFIGS[symbol_lower]
-    loaders = {
-        "ssga": _load_ssga_excel,
-        "ishares": _load_ishares_csv,
-        "nasdaq": _load_nasdaq_json,
-    }
-    try:
-        loader = loaders[config.provider]
-    except KeyError as exc:
-        raise ValueError(f"Unknown provider: {config.provider}") from exc
-
-    # 🔄 Load data based on provider
-    df = loader(config.url)
-
-    # 🧹 Clean and filter
-    df = _filter_and_clean(df, config.provider)
-    _validate_count(symbol_lower, len(df))
-
-    # 💾 Save outputs
-    _save_holdings(df, symbol_lower, output_dir)
-
+    df = filter_and_clean(load_holdings(config), config.provider)
+    validate_count(symbol_lower, len(df))
+    save_holdings(df, symbol_lower, output_dir)
     return df
 
 
 def get_spy_holdings() -> pl.DataFrame:
-    """📊 Get ticker symbols from the SPY ETF.
-
-    Returns:
-        DataFrame with SPY ticker symbols
-    """
+    """📊 Get ticker symbols from the SPY ETF."""
     return get_etf_holdings("spy")
 
 
 def get_mdy_holdings() -> pl.DataFrame:
-    """📊 Get ticker symbols from the MDY ETF.
-
-    Returns:
-        DataFrame with MDY ticker symbols
-    """
+    """📊 Get ticker symbols from the MDY ETF."""
     return get_etf_holdings("mdy")
 
 
 def get_spsm_holdings() -> pl.DataFrame:
-    """📊 Get ticker symbols from the SPSM ETF.
-
-    Returns:
-        DataFrame with SPSM ticker symbols
-    """
+    """📊 Get ticker symbols from the SPSM ETF."""
     return get_etf_holdings("spsm")
 
 
 def get_qqq_holdings() -> pl.DataFrame:
-    """📊 Get ticker symbols from the Nasdaq-100.
-
-    Returns:
-        DataFrame with QQQ ticker symbols
-    """
+    """📊 Get ticker symbols from the Nasdaq-100."""
     return get_etf_holdings("qqq")
 
 
 def get_iwm_holdings() -> pl.DataFrame:
-    """📊 Get ticker symbols from the IWM ETF.
-
-    Returns:
-        DataFrame with IWM ticker symbols
-    """
+    """📊 Get ticker symbols from the IWM ETF."""
     return get_etf_holdings("iwm")
 
 
 def main() -> None:
-    """🚀 Main function to download all ETF holdings."""
+    """🚀 Download all ETF holdings."""
     print("📥 Downloading ETF holdings...")
     output_dir = Path.cwd()
     results = {}
 
-    for symbol in ETF_CONFIGS.keys():
+    for symbol in ETF_CONFIGS:
         print(f"  ⏳ Processing {symbol.upper()}...")
         df = get_etf_holdings(symbol, output_dir)
         count = len(df)
         results[symbol] = count
         print(f"  ✅ {symbol.upper()} complete! ({count} rows)")
 
-    _write_metadata(results, output_dir)
+    write_metadata(results, output_dir)
     print("🎉 All holdings downloaded successfully!")
 
 

--- a/src/index_etfs/holdings.py
+++ b/src/index_etfs/holdings.py
@@ -8,6 +8,7 @@ import io
 import json
 import math
 import urllib.request
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
@@ -15,31 +16,50 @@ from typing import Literal
 import polars as pl
 
 
+Provider = Literal["ssga", "ishares", "nasdaq"]
+
+
+@dataclass(frozen=True)
+class ETFConfig:
+    url: str
+    provider: Provider
+    watchlist_name: str
+    expected_count: int
+
+
 # 🎯 ETF Configuration
 ETF_CONFIGS = {
-    "spy": {
-        "url": "https://www.ssga.com/us/en/individual/library-content/products/fund-data/etfs/us/holdings-daily-us-en-spy.xlsx",
-        "provider": "ssga",
-    },
-    "mdy": {
-        "url": "https://www.ssga.com/us/en/individual/library-content/products/fund-data/etfs/us/holdings-daily-us-en-mdy.xlsx",
-        "provider": "ssga",
-    },
-    "spsm": {
-        "url": "https://www.ssga.com/us/en/individual/library-content/products/fund-data/etfs/us/holdings-daily-us-en-spsm.xlsx",
-        "provider": "ssga",
-    },
-    "qqq": {
-        "url": "https://api.nasdaq.com/api/quote/list-type/nasdaq100",
-        "provider": "nasdaq",
-    },
-    "iwm": {
-        "url": "https://www.blackrock.com/varnish-api/blk-one01-product-data/product-data/api/v1/get-fund-document?appType=PRODUCT_PAGE&appSubType=ISHARES&targetSite=us-ishares&locale=en_US&portfolioId=239710&userType=individual&component=holdings",
-        "provider": "ishares",
-    },
+    "spy": ETFConfig(
+        url="https://www.ssga.com/us/en/individual/library-content/products/fund-data/etfs/us/holdings-daily-us-en-spy.xlsx",
+        provider="ssga",
+        watchlist_name="sp500",
+        expected_count=503,
+    ),
+    "mdy": ETFConfig(
+        url="https://www.ssga.com/us/en/individual/library-content/products/fund-data/etfs/us/holdings-daily-us-en-mdy.xlsx",
+        provider="ssga",
+        watchlist_name="sp400",
+        expected_count=400,
+    ),
+    "spsm": ETFConfig(
+        url="https://www.ssga.com/us/en/individual/library-content/products/fund-data/etfs/us/holdings-daily-us-en-spsm.xlsx",
+        provider="ssga",
+        watchlist_name="sp600",
+        expected_count=600,
+    ),
+    "qqq": ETFConfig(
+        url="https://api.nasdaq.com/api/quote/list-type/nasdaq100",
+        provider="nasdaq",
+        watchlist_name="nasdaq100",
+        expected_count=100,
+    ),
+    "iwm": ETFConfig(
+        url="https://www.blackrock.com/varnish-api/blk-one01-product-data/product-data/api/v1/get-fund-document?appType=PRODUCT_PAGE&appSubType=ISHARES&targetSite=us-ishares&locale=en_US&portfolioId=239710&userType=individual&component=holdings",
+        provider="ishares",
+        watchlist_name="russell2000",
+        expected_count=2000,
+    ),
 }
-
-ETFSymbol = Literal["spy", "mdy", "spsm", "qqq", "iwm"]
 
 FIREFOX_HEADERS = {
     "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0",
@@ -48,20 +68,6 @@ FIREFOX_HEADERS = {
 }
 
 TRADINGVIEW_SCAN_URL = "https://scanner.tradingview.com/america/scan"
-WATCHLIST_NAMES = {
-    "spy": "sp500",
-    "mdy": "sp400",
-    "spsm": "sp600",
-    "qqq": "nasdaq100",
-    "iwm": "russell2000",
-}
-EXPECTED_COUNTS = {
-    "spy": 503,
-    "mdy": 400,
-    "spsm": 600,
-    "qqq": 100,
-    "iwm": 2000,
-}
 MIN_EXPECTED_RATIO = 0.9
 
 
@@ -70,7 +76,7 @@ def _validate_count(symbol: str, count: int) -> None:
     if count == 0:
         raise ValueError(f"{symbol.upper()} returned zero rows")
 
-    expected = EXPECTED_COUNTS[symbol]
+    expected = ETF_CONFIGS[symbol].expected_count
     minimum = math.ceil(expected * MIN_EXPECTED_RATIO)
     if count < minimum:
         raise ValueError(
@@ -89,14 +95,15 @@ def _write_metadata(results: dict[str, int], output_dir: Path | None = None) -> 
         .isoformat()
         .replace("+00:00", "Z"),
         "watchlists": {
-            WATCHLIST_NAMES[symbol]: {
+            config.watchlist_name: {
                 "count": count,
-                "expected_count": EXPECTED_COUNTS[symbol],
-                "minimum_count": math.ceil(EXPECTED_COUNTS[symbol] * MIN_EXPECTED_RATIO),
+                "expected_count": config.expected_count,
+                "minimum_count": math.ceil(config.expected_count * MIN_EXPECTED_RATIO),
                 "source": symbol,
-                "source_url": ETF_CONFIGS[symbol]["url"],
+                "source_url": config.url,
             }
             for symbol, count in results.items()
+            for config in [ETF_CONFIGS[symbol]]
         },
     }
 
@@ -257,21 +264,23 @@ def _save_holdings(df: pl.DataFrame, symbol: str, output_dir: Path | None = None
     tickers_dir.mkdir(exist_ok=True)
     (tickers_dir / f"{symbol}.txt").write_text("\n".join(tickers) + "\n")
 
-    watchlist_name = WATCHLIST_NAMES.get(symbol)
-    if watchlist_name:
-        watchlist_dir = output_dir / "watchlists"
-        watchlist_dir.mkdir(exist_ok=True)
-        symbols = _tradingview_symbols(tickers)
-        missing = [ticker for ticker in tickers if ticker not in symbols]
-        if missing:
-            print(f"⚠️  No TradingView metadata for {', '.join(missing)}")
-        (watchlist_dir / f"{watchlist_name}.txt").write_text(
-            "\n".join(_watchlist_lines(tickers, symbols)) + "\n"
-        )
+    config = ETF_CONFIGS.get(symbol)
+    if config is None:
+        return
+
+    watchlist_dir = output_dir / "watchlists"
+    watchlist_dir.mkdir(exist_ok=True)
+    symbols = _tradingview_symbols(tickers)
+    missing = [ticker for ticker in tickers if ticker not in symbols]
+    if missing:
+        print(f"⚠️  No TradingView metadata for {', '.join(missing)}")
+    (watchlist_dir / f"{config.watchlist_name}.txt").write_text(
+        "\n".join(_watchlist_lines(tickers, symbols)) + "\n"
+    )
 
 
 def get_etf_holdings(
-    symbol: ETFSymbol,
+    symbol: str,
     output_dir: Path | None = None,
 ) -> pl.DataFrame:
     """📈 Get ticker symbols for a specific ETF.
@@ -298,21 +307,21 @@ def get_etf_holdings(
         )
 
     config = ETF_CONFIGS[symbol_lower]
-    provider = config["provider"]
-    url = config["url"]
+    loaders = {
+        "ssga": _load_ssga_excel,
+        "ishares": _load_ishares_csv,
+        "nasdaq": _load_nasdaq_json,
+    }
+    try:
+        loader = loaders[config.provider]
+    except KeyError as exc:
+        raise ValueError(f"Unknown provider: {config.provider}") from exc
 
     # 🔄 Load data based on provider
-    if provider == "ssga":
-        df = _load_ssga_excel(url)
-    elif provider == "ishares":
-        df = _load_ishares_csv(url)
-    elif provider == "nasdaq":
-        df = _load_nasdaq_json(url)
-    else:
-        raise ValueError(f"Unknown provider: {provider}")
+    df = loader(config.url)
 
     # 🧹 Clean and filter
-    df = _filter_and_clean(df, provider)
+    df = _filter_and_clean(df, config.provider)
     _validate_count(symbol_lower, len(df))
 
     # 💾 Save outputs
@@ -374,7 +383,7 @@ def main() -> None:
 
     for symbol in ETF_CONFIGS.keys():
         print(f"  ⏳ Processing {symbol.upper()}...")
-        df = get_etf_holdings(symbol, output_dir)  # type: ignore[arg-type]
+        df = get_etf_holdings(symbol, output_dir)
         count = len(df)
         results[symbol] = count
         print(f"  ✅ {symbol.upper()} complete! ({count} rows)")

--- a/src/index_etfs/outputs.py
+++ b/src/index_etfs/outputs.py
@@ -1,0 +1,114 @@
+"""Write ticker, watchlist, and metadata outputs."""
+
+import json
+import math
+import urllib.request
+from datetime import UTC, datetime
+from pathlib import Path
+
+import polars as pl
+
+from .catalog import ETF_CONFIGS, MIN_EXPECTED_RATIO
+from .sources import FIREFOX_HEADERS
+
+TRADINGVIEW_SCAN_URL = "https://scanner.tradingview.com/america/scan"
+
+
+def write_metadata(results: dict[str, int], output_dir: Path | None = None) -> None:
+    """Write latest generated counts and source URLs."""
+    if output_dir is None:
+        output_dir = Path.cwd()
+
+    metadata = {
+        "generated_at": datetime.now(UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        "watchlists": {
+            config.watchlist_name: {
+                "count": count,
+                "expected_count": config.expected_count,
+                "minimum_count": math.ceil(config.expected_count * MIN_EXPECTED_RATIO),
+                "source": symbol,
+                "source_url": config.url,
+            }
+            for symbol, count in results.items()
+            for config in [ETF_CONFIGS[symbol]]
+        },
+    }
+
+    metadata_dir = output_dir / "metadata"
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    (metadata_dir / "latest.json").write_text(json.dumps(metadata, indent=2) + "\n")
+
+
+def tradingview_symbols(tickers: list[str], chunk_size: int = 200) -> dict[str, tuple[str, str]]:
+    """Map tickers to TradingView symbols and sector-ish group names."""
+    symbols = {}
+    headers = FIREFOX_HEADERS | {
+        "Content-Type": "application/json",
+        "Origin": "https://www.tradingview.com",
+        "Referer": "https://www.tradingview.com/",
+    }
+
+    for start in range(0, len(tickers), chunk_size):
+        chunk = tickers[start : start + chunk_size]
+        payload = {
+            "filter": [{"left": "name", "operation": "in_range", "right": chunk}],
+            "columns": ["name", "sector", "industry"],
+            "markets": ["america"],
+        }
+        request = urllib.request.Request(
+            TRADINGVIEW_SCAN_URL,
+            data=json.dumps(payload).encode(),
+            headers=headers,
+        )
+        with urllib.request.urlopen(request, timeout=30) as response:
+            rows = json.load(response).get("data", [])
+
+        for row in rows:
+            data = row.get("d", [])
+            ticker = data[0] if data else None
+            symbol = row.get("s", "")
+            group = next((value for value in data[1:3] if value), "Other")
+            if ticker in chunk and ":" in symbol:
+                symbols.setdefault(ticker, (symbol, group))
+
+    return symbols
+
+
+def watchlist_lines(tickers: list[str], symbols: dict[str, tuple[str, str]]) -> list[str]:
+    """Build TradingView watchlist lines grouped by ### headers."""
+    groups: dict[str, list[str]] = {}
+    for ticker in tickers:
+        symbol, group = symbols.get(ticker, (ticker, "Other"))
+        groups.setdefault(group, []).append(symbol)
+
+    return [line for group in sorted(groups) for line in (f"###{group}", *groups[group])]
+
+
+def save_holdings(df: pl.DataFrame, symbol: str, output_dir: Path | None = None) -> None:
+    """Save ticker symbols and TradingView watchlists."""
+    if output_dir is None:
+        output_dir = Path.cwd()
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    tickers = df["Ticker"].to_list()
+    tickers_dir = output_dir / "tickers"
+    tickers_dir.mkdir(exist_ok=True)
+    (tickers_dir / f"{symbol}.txt").write_text("\n".join(tickers) + "\n")
+
+    config = ETF_CONFIGS.get(symbol)
+    if config is None:
+        return
+
+    watchlist_dir = output_dir / "watchlists"
+    watchlist_dir.mkdir(exist_ok=True)
+    symbols = tradingview_symbols(tickers)
+    missing = [ticker for ticker in tickers if ticker not in symbols]
+    if missing:
+        print(f"⚠️  No TradingView metadata for {', '.join(missing)}")
+    (watchlist_dir / f"{config.watchlist_name}.txt").write_text(
+        "\n".join(watchlist_lines(tickers, symbols)) + "\n"
+    )

--- a/src/index_etfs/sources.py
+++ b/src/index_etfs/sources.py
@@ -1,0 +1,84 @@
+"""Download and clean holdings data from upstream providers."""
+
+import io
+import json
+import urllib.request
+
+import polars as pl
+
+from .catalog import ETFConfig, Provider
+
+FIREFOX_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0",
+    "Accept": "*/*",
+    "Accept-Language": "en-US,en;q=0.5",
+}
+
+
+def read_url(url: str) -> io.BytesIO:
+    """Read a URL with browser-ish headers."""
+    request = urllib.request.Request(url, headers=FIREFOX_HEADERS)
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return io.BytesIO(response.read())
+
+
+def load_ssga_excel(url: str) -> pl.DataFrame:
+    """Load SSGA Excel format holdings data."""
+    df_dict = pl.read_excel(read_url(url), sheet_id=0, read_options={"header_row": 4})
+    return list(df_dict.values())[0] if isinstance(df_dict, dict) else df_dict
+
+
+def load_ishares_csv(url: str) -> pl.DataFrame:
+    """Load iShares CSV format holdings data."""
+    df = pl.read_csv(
+        read_url(url),
+        skip_rows=9,
+        columns=["Ticker", "Name", "Weight (%)", "Market Currency"],
+        truncate_ragged_lines=True,
+    )
+    return df.rename({"Weight (%)": "Weight"})
+
+
+def load_nasdaq_json(url: str) -> pl.DataFrame:
+    """Load Nasdaq-100 symbols from Nasdaq's public JSON endpoint."""
+    rows = json.load(read_url(url)).get("data", {}).get("data", {}).get("rows")
+    if not rows:
+        raise ValueError("Nasdaq response did not contain any Nasdaq-100 rows")
+
+    tickers = [row["symbol"].strip().replace("/", ".") for row in rows if row.get("symbol")]
+    if not tickers:
+        raise ValueError("Nasdaq response did not contain any symbols")
+
+    return pl.DataFrame({"Ticker": tickers})
+
+
+def load_holdings(config: ETFConfig) -> pl.DataFrame:
+    """Load holdings from the configured provider."""
+    loaders = {
+        "ssga": load_ssga_excel,
+        "ishares": load_ishares_csv,
+        "nasdaq": load_nasdaq_json,
+    }
+    try:
+        loader = loaders[config.provider]
+    except KeyError as exc:
+        raise ValueError(f"Unknown provider: {config.provider}") from exc
+    return loader(config.url)
+
+
+def filter_and_clean(df: pl.DataFrame, provider: Provider) -> pl.DataFrame:
+    """Filter provider holdings down to sorted ticker symbols."""
+    if len(df) == 0:
+        return df.select("Ticker") if "Ticker" in df.columns else pl.DataFrame({"Ticker": []})
+
+    if provider in ("ssga", "ishares"):
+        currency_col = "Local Currency" if provider == "ssga" else "Market Currency"
+        df = df.filter((pl.col(currency_col) == "USD") & (pl.col("Ticker") != "-"))
+
+    return df.filter(
+        pl.col("Ticker").is_not_null()
+        & (pl.col("Ticker") != "")
+        & (pl.col("Ticker") != "-")
+        & ~pl.col("Ticker").str.contains("_", literal=True)
+        & ~pl.col("Ticker").str.contains(" ", literal=True)
+    ).select("Ticker").sort("Ticker")

--- a/tests/test_holdings.py
+++ b/tests/test_holdings.py
@@ -1,4 +1,4 @@
-"""🧪 Tests for the holdings module."""
+"""Tests for the holdings pipeline."""
 
 import io
 import json
@@ -10,7 +10,7 @@ import pytest
 
 import index_etfs.catalog as catalog
 import index_etfs.holdings as holdings
-from index_etfs.catalog import validate_count
+from index_etfs.catalog import ETFConfig, validate_count
 from index_etfs.holdings import (
     get_etf_holdings,
     get_iwm_holdings,
@@ -19,15 +19,11 @@ from index_etfs.holdings import (
     get_spsm_holdings,
     get_spy_holdings,
 )
-from index_etfs.outputs import (
-    save_holdings,
-    tradingview_symbols,
-    watchlist_lines,
-    write_metadata,
-)
+from index_etfs.outputs import save_holdings, tradingview_symbols, watchlist_lines, write_metadata
 from index_etfs.sources import (
     FIREFOX_HEADERS,
     filter_and_clean,
+    load_holdings,
     load_ishares_csv,
     load_nasdaq_json,
     load_ssga_excel,
@@ -35,12 +31,8 @@ from index_etfs.sources import (
 )
 
 
-# 🎯 Test Fixtures
-
-
 @pytest.fixture
 def sample_ssga_data() -> pl.DataFrame:
-    """Create sample SSGA-style holdings data."""
     return pl.DataFrame(
         {
             "Ticker": ["AAPL", "MSFT", "GOOGL", "-", "NVDA"],
@@ -53,7 +45,6 @@ def sample_ssga_data() -> pl.DataFrame:
 
 @pytest.fixture
 def sample_ishares_data() -> pl.DataFrame:
-    """Create sample iShares-style holdings data."""
     return pl.DataFrame(
         {
             "Ticker": ["AAPL", "MSFT", "-", "GOOGL"],
@@ -64,319 +55,143 @@ def sample_ishares_data() -> pl.DataFrame:
     )
 
 
-@pytest.fixture
-def sample_nasdaq_data() -> pl.DataFrame:
-    """Create sample Nasdaq-100 holdings data."""
-    return pl.DataFrame({"Ticker": ["AAPL", "MSFT", "GOOGL"]})
-
-
-@pytest.fixture
-def temp_output_dir(tmp_path: Path) -> Path:
-    """Create a temporary directory for test outputs."""
-    return tmp_path / "holdings_output"
-
-
-# 🧹 Tests for filter_and_clean
-
-
 @pytest.mark.parametrize(
-    ("provider", "expected_len"),
+    ("provider", "rows", "expected"),
     [
-        ("ssga", 3),  # Should filter out EUR and "-" ticker
-        ("ishares", 2),  # Should filter out GBP and "-" ticker
-        ("nasdaq", 3),  # No currency filtering for nasdaq
+        ("ssga", "sample_ssga_data", ["AAPL", "GOOGL", "MSFT"]),
+        ("ishares", "sample_ishares_data", ["AAPL", "MSFT"]),
+        ("nasdaq", None, ["AAPL", "GOOGL", "MSFT"]),
     ],
 )
-def test_filter_and_clean(
-    provider: str,
-    expected_len: int,
-    sample_ssga_data: pl.DataFrame,
-    sample_ishares_data: pl.DataFrame,
-    sample_nasdaq_data: pl.DataFrame,
-) -> None:
-    """🧪 Test filtering and cleaning data for different providers."""
-    if provider == "ssga":
-        data = sample_ssga_data
-    elif provider == "ishares":
-        data = sample_ishares_data
-    else:
-        data = sample_nasdaq_data
+def test_filter_and_clean(provider: str, rows: str | None, expected: list[str], request: pytest.FixtureRequest) -> None:
+    df = request.getfixturevalue(rows) if rows else pl.DataFrame({"Ticker": ["MSFT", "", "AAPL", "GOOGL"]})
 
-    result = filter_and_clean(data, provider)
-
-    assert len(result) == expected_len
-    assert set(result.columns) == {"Ticker"}
-    # ✅ Check sorted alphabetically
-    tickers = result["Ticker"].to_list()
-    assert tickers == sorted(tickers)
+    assert filter_and_clean(df, provider).to_dict(as_series=False) == {"Ticker": expected}
 
 
-def test_filter_and_clean_removes_dash_tickers(sample_ssga_data: pl.DataFrame) -> None:
-    """🧪 Test that dash tickers are filtered out."""
-    result = filter_and_clean(sample_ssga_data, "ssga")
-    assert "-" not in result["Ticker"].to_list()
+def test_filter_and_clean_handles_empty_dataframe() -> None:
+    result = filter_and_clean(pl.DataFrame({"Ticker": []}), "nasdaq")
 
-
-def test_filter_and_clean_keeps_only_usd(sample_ssga_data: pl.DataFrame) -> None:
-    """🧪 Test that only USD currencies are kept for SSGA."""
-    result = filter_and_clean(sample_ssga_data, "ssga")
-    # 💰 Should only have USD tickers (NVDA has EUR so should be filtered)
-    assert len(result) == 3
-    assert all(ticker in ["AAPL", "MSFT", "GOOGL"] for ticker in result["Ticker"])
-
-
-# 💾 Tests for save_holdings
-
-
-def test_save_holdings_creates_txt_file(
-    sample_ssga_data: pl.DataFrame, temp_output_dir: Path
-) -> None:
-    """🧪 Test that save_holdings creates a ticker text file."""
-    df = filter_and_clean(sample_ssga_data, "ssga")
-    save_holdings(df, "test", temp_output_dir)
-
-    assert (temp_output_dir / "tickers" / "test.txt").exists()
-
-
-def test_save_holdings_writes_sorted_tickers_with_trailing_newline(
-    sample_ssga_data: pl.DataFrame, temp_output_dir: Path
-) -> None:
-    """🧪 Test ticker text output shape."""
-    df = filter_and_clean(sample_ssga_data, "ssga")
-    save_holdings(df, "test", temp_output_dir)
-
-    assert (temp_output_dir / "tickers" / "test.txt").read_text() == "AAPL\nGOOGL\nMSFT\n"
-
-
-def test_save_holdings_defaults_to_cwd(
-    sample_ssga_data: pl.DataFrame, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """🧪 Test that save_holdings uses current directory when no output_dir given."""
-    monkeypatch.chdir(tmp_path)
-    df = filter_and_clean(sample_ssga_data, "ssga")
-    save_holdings(df, "test")
-
-    assert (tmp_path / "tickers" / "test.txt").exists()
-
-
-@patch("index_etfs.outputs.tradingview_symbols")
-def test_save_holdings_writes_tradingview_watchlist(
-    mock_symbols: MagicMock, sample_ssga_data: pl.DataFrame, temp_output_dir: Path
-) -> None:
-    """🧪 Test TradingView watchlist output shape."""
-    mock_symbols.return_value = {
-        "AAPL": ("NASDAQ:AAPL", "Technology"),
-        "GOOGL": ("NASDAQ:GOOGL", "Communication"),
-        "MSFT": ("NASDAQ:MSFT", "Technology"),
-    }
-    df = filter_and_clean(sample_ssga_data, "ssga")
-
-    save_holdings(df, "spy", temp_output_dir)
-
-    assert (temp_output_dir / "watchlists" / "sp500.txt").read_text() == (
-        "###Communication\nNASDAQ:GOOGL\n###Technology\nNASDAQ:AAPL\nNASDAQ:MSFT\n"
-    )
-
-
-# 🏢 Tests for loader functions
+    assert result.to_dict(as_series=False) == {"Ticker": []}
 
 
 @patch("index_etfs.sources.read_url", return_value=io.BytesIO())
 @patch("index_etfs.sources.pl.read_excel")
-def test_load_ssga_excel_handles_dict_response(
-    mock_read_excel: MagicMock, _mock_read_url: MagicMock
-) -> None:
-    """🧪 Test loading SSGA Excel when response is a dict."""
-    mock_df = pl.DataFrame({"Ticker": ["AAPL"], "Weight": [7.5]})
-    mock_read_excel.return_value = {"Sheet1": mock_df}
+def test_load_ssga_excel_handles_polars_shapes(mock_read_excel: MagicMock, _mock_read_url: MagicMock) -> None:
+    df = pl.DataFrame({"Ticker": ["AAPL"]})
+    mock_read_excel.side_effect = [{"Sheet1": df}, df]
 
-    result = load_ssga_excel("http://example.com/data.xlsx")
-
-    assert isinstance(result, pl.DataFrame)
-    assert result.equals(mock_df)
-
-
-@patch("index_etfs.sources.read_url", return_value=io.BytesIO())
-@patch("index_etfs.sources.pl.read_excel")
-def test_load_ssga_excel_handles_dataframe_response(
-    mock_read_excel: MagicMock, _mock_read_url: MagicMock
-) -> None:
-    """🧪 Test loading SSGA Excel when response is already a DataFrame."""
-    mock_df = pl.DataFrame({"Ticker": ["AAPL"], "Weight": [7.5]})
-    mock_read_excel.return_value = mock_df
-
-    result = load_ssga_excel("http://example.com/data.xlsx")
-
-    assert isinstance(result, pl.DataFrame)
-    assert result.equals(mock_df)
+    assert load_ssga_excel("https://example.com/file.xlsx").equals(df)
+    assert load_ssga_excel("https://example.com/file.xlsx").equals(df)
 
 
 @patch("index_etfs.sources.read_url", return_value=io.BytesIO())
 @patch("index_etfs.sources.pl.read_csv")
-def test_load_ishares_csv_renames_weight_column(
-    mock_read_csv: MagicMock, _mock_read_url: MagicMock
-) -> None:
-    """🧪 Test that iShares loader renames Weight (%) column."""
-    mock_df = pl.DataFrame(
-        {
-            "Ticker": ["AAPL"],
-            "Name": ["Apple"],
-            "Weight (%)": [5.0],
-            "Market Currency": ["USD"],
-        }
+def test_load_ishares_csv_renames_weight(mock_read_csv: MagicMock, _mock_read_url: MagicMock) -> None:
+    mock_read_csv.return_value = pl.DataFrame(
+        {"Ticker": ["AAPL"], "Name": ["Apple"], "Weight (%)": [5.0], "Market Currency": ["USD"]}
     )
-    mock_read_csv.return_value = mock_df
 
-    result = load_ishares_csv("http://example.com/data.csv")
+    assert load_ishares_csv("https://example.com/file.csv").columns == [
+        "Ticker",
+        "Name",
+        "Weight",
+        "Market Currency",
+    ]
 
-    assert "Weight" in result.columns
-    assert "Weight (%)" not in result.columns
 
-
-@patch(
-    "index_etfs.sources.read_url",
-    return_value=io.BytesIO(
-        b'{"data":{"data":{"rows":[{"symbol":"AAPL"},{"symbol":"BRK/B"}]}}}'
-    ),
+@pytest.mark.parametrize(
+    ("payload", "match"),
+    [
+        (b'{"data":{"data":{"rows":[{"symbol":"AAPL"},{"symbol":"BRK/B"}]}}}', None),
+        (b'{"data":{}}', "Nasdaq response"),
+        (b'{"data":{"data":{"rows":[{}]}}}', "symbols"),
+    ],
 )
-def test_load_nasdaq_json_returns_tickers(_mock_read_url: MagicMock) -> None:
-    """🧪 Test loading Nasdaq-100 JSON."""
-    result = load_nasdaq_json("http://example.com/data.json")
-
-    assert result["Ticker"].to_list() == ["AAPL", "BRK.B"]
-
-
-@patch("index_etfs.sources.read_url", return_value=io.BytesIO(b'{"data":{}}'))
-def test_load_nasdaq_json_raises_on_missing_rows(_mock_read_url: MagicMock) -> None:
-    """🧪 Test Nasdaq JSON fails closed on bad payloads."""
-    with pytest.raises(ValueError, match="Nasdaq response"):
-        load_nasdaq_json("http://example.com/data.json")
-
-
-@patch(
-    "index_etfs.sources.read_url",
-    return_value=io.BytesIO(b'{"data":{"data":{"rows":[{}]}}}'),
-)
-def test_load_nasdaq_json_raises_on_missing_symbols(_mock_read_url: MagicMock) -> None:
-    """🧪 Test Nasdaq JSON fails closed when rows have no symbols."""
-    with pytest.raises(ValueError, match="symbols"):
-        load_nasdaq_json("http://example.com/data.json")
+def test_load_nasdaq_json(payload: bytes, match: str | None) -> None:
+    with patch("index_etfs.sources.read_url", return_value=io.BytesIO(payload)):
+        if match:
+            with pytest.raises(ValueError, match=match):
+                load_nasdaq_json("https://example.com/data.json")
+        else:
+            assert load_nasdaq_json("https://example.com/data.json")["Ticker"].to_list() == ["AAPL", "BRK.B"]
 
 
 @patch("index_etfs.sources.urllib.request.urlopen", return_value=io.BytesIO(b"ok"))
-def test_read_url_uses_firefox_headers(mock_urlopen: MagicMock) -> None:
-    """🧪 Test URL reads use browser-ish headers."""
-    assert read_url("http://example.com/data.csv").read() == b"ok"
+def test_read_url_uses_headers(mock_urlopen: MagicMock) -> None:
+    assert read_url("https://example.com/data.csv").read() == b"ok"
+    assert mock_urlopen.call_args.args[0].get_header("User-agent") == FIREFOX_HEADERS["User-Agent"]
 
-    request = mock_urlopen.call_args.args[0]
-    assert request.get_header("User-agent") == FIREFOX_HEADERS["User-Agent"]
+
+def test_load_holdings_rejects_unknown_provider() -> None:
+    with pytest.raises(ValueError, match="Unknown provider"):
+        load_holdings(ETFConfig("https://example.com/data", "bad", "bad", 1))  # type: ignore[arg-type]
 
 
 @patch(
-    "index_etfs.sources.urllib.request.urlopen",
+    "index_etfs.outputs.urllib.request.urlopen",
     return_value=io.BytesIO(
         b'{"data":[{"s":"NASDAQ:AAPL","d":["AAPL","Technology Services","Consumer Electronics"]}]}'
     ),
 )
-def test_tradingview_symbols_maps_symbols_and_groups(mock_urlopen: MagicMock) -> None:
-    """🧪 Test TradingView scanner metadata mapping."""
+def test_tradingview_symbols(mock_urlopen: MagicMock) -> None:
     assert tradingview_symbols(["AAPL"]) == {"AAPL": ("NASDAQ:AAPL", "Technology Services")}
-
     request = mock_urlopen.call_args.args[0]
     assert request.get_header("Content-type") == "application/json"
     assert json.loads(request.data)["columns"] == ["name", "sector", "industry"]
 
 
 def test_watchlist_lines_groups_by_header() -> None:
-    """🧪 Test TradingView ### section output."""
     assert watchlist_lines(
         ["AAPL", "MSFT", "BRK.B"],
-        {
-            "AAPL": ("NASDAQ:AAPL", "Technology"),
-            "MSFT": ("NASDAQ:MSFT", "Technology"),
-        },
+        {"AAPL": ("NASDAQ:AAPL", "Technology"), "MSFT": ("NASDAQ:MSFT", "Technology")},
     ) == ["###Other", "BRK.B", "###Technology", "NASDAQ:AAPL", "NASDAQ:MSFT"]
 
 
-# 📈 Tests for get_etf_holdings
+@patch("index_etfs.outputs.tradingview_symbols", return_value={"AAPL": ("NASDAQ:AAPL", "Technology")})
+def test_save_holdings_writes_outputs(_mock_symbols: MagicMock, tmp_path: Path) -> None:
+    save_holdings(pl.DataFrame({"Ticker": ["AAPL"]}), "spy", tmp_path)
+    save_holdings(pl.DataFrame({"Ticker": ["TEST"]}), "test", tmp_path)
+
+    assert (tmp_path / "tickers" / "spy.txt").read_text() == "AAPL\n"
+    assert (tmp_path / "watchlists" / "sp500.txt").read_text() == "###Technology\nNASDAQ:AAPL\n"
+    assert (tmp_path / "tickers" / "test.txt").read_text() == "TEST\n"
 
 
-def test_get_etf_holdings_raises_on_unknown_symbol() -> None:
-    """🧪 Test that get_etf_holdings raises ValueError for unknown symbols."""
+def test_write_metadata(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    write_metadata({"spy": 503}, tmp_path)
+    monkeypatch.chdir(tmp_path)
+    write_metadata({"qqq": 100})
+
+    metadata = json.loads((tmp_path / "metadata" / "latest.json").read_text())
+    assert metadata["generated_at"].endswith("Z")
+    assert metadata["watchlists"]["nasdaq100"]["source_url"] == catalog.ETF_CONFIGS["qqq"].url
+
+
+@patch("index_etfs.outputs.tradingview_symbols", return_value={})
+def test_get_etf_holdings_downloads_cleans_and_writes(_mock_symbols: MagicMock, tmp_path: Path) -> None:
+    rows = [{"symbol": f"TICK{i}"} for i in range(100)]
+    payload = json.dumps({"data": {"data": {"rows": rows}}}).encode()
+
+    with patch("index_etfs.sources.read_url", return_value=io.BytesIO(payload)):
+        result = get_etf_holdings("QQQ", tmp_path)
+
+    assert len(result) == 100
+    assert (tmp_path / "tickers" / "qqq.txt").read_text().startswith("TICK0\n")
+    assert (tmp_path / "watchlists" / "nasdaq100.txt").exists()
+
+
+def test_get_etf_holdings_rejects_unknown_symbol() -> None:
     with pytest.raises(ValueError, match="Unknown ETF symbol"):
-        get_etf_holdings("INVALID")  # type: ignore[arg-type]
+        get_etf_holdings("INVALID")
 
 
-
-@pytest.mark.parametrize("symbol", ["spy", "iwm", "qqq"])
-@patch("index_etfs.holdings.load_holdings")
-@patch("index_etfs.holdings.filter_and_clean")
-@patch("index_etfs.holdings.save_holdings")
-def test_get_etf_holdings_uses_configured_source(
-    mock_save: MagicMock,
-    mock_filter: MagicMock,
-    mock_load: MagicMock,
-    symbol: str,
-    sample_ssga_data: pl.DataFrame,
-) -> None:
-    """🧪 Test that configured ETFs load, clean, and save."""
-    config = catalog.ETF_CONFIGS[symbol]
-    mock_load.return_value = sample_ssga_data
-    mock_filter.return_value = sample_ssga_data
-
-    with patch("index_etfs.holdings.validate_count"):
-        get_etf_holdings(symbol)
-
-    mock_load.assert_called_once_with(config)
-    mock_filter.assert_called_once_with(sample_ssga_data, config.provider)
-    mock_save.assert_called_once()
-
-
-@patch("index_etfs.holdings.load_holdings")
-@patch("index_etfs.holdings.filter_and_clean")
-@patch("index_etfs.holdings.save_holdings")
-def test_get_etf_holdings_passes_output_dir(
-    mock_save: MagicMock,
-    mock_filter: MagicMock,
-    mock_load: MagicMock,
-    sample_ssga_data: pl.DataFrame,
-    temp_output_dir: Path,
-) -> None:
-    """🧪 Test that output_dir is passed to save function."""
-    mock_load.return_value = sample_ssga_data
-    mock_filter.return_value = sample_ssga_data
-
-    with patch("index_etfs.holdings.validate_count"):
-        get_etf_holdings("spy", output_dir=temp_output_dir)
-
-    mock_save.assert_called_once()
-    call_args = mock_save.call_args
-    assert call_args[0][1] == "spy"  # symbol
-    assert call_args[0][2] == temp_output_dir  # output_dir
-
-
-@patch("index_etfs.holdings.load_holdings")
-@patch("index_etfs.holdings.filter_and_clean")
-@patch("index_etfs.holdings.save_holdings")
-def test_get_etf_holdings_returns_dataframe(
-    mock_save: MagicMock,
-    mock_filter: MagicMock,
-    mock_load: MagicMock,
-    sample_ssga_data: pl.DataFrame,
-) -> None:
-    """🧪 Test that get_etf_holdings returns a DataFrame."""
-    mock_load.return_value = sample_ssga_data
-    cleaned_df = filter_and_clean(sample_ssga_data, "ssga")
-    mock_filter.return_value = cleaned_df
-
-    with patch("index_etfs.holdings.validate_count"):
-        result = get_etf_holdings("spy")
-
-    assert isinstance(result, pl.DataFrame)
-    assert result.equals(cleaned_df)
-
-
-# 🎯 Tests for individual ETF functions
+def test_validate_count_rejects_empty_and_tiny_results() -> None:
+    with pytest.raises(ValueError, match="zero rows"):
+        validate_count("spy", 0)
+    with pytest.raises(ValueError, match="expected at least"):
+        validate_count("iwm", 1799)
+    validate_count("iwm", 1800)
 
 
 @pytest.mark.parametrize(
@@ -390,10 +205,7 @@ def test_get_etf_holdings_returns_dataframe(
     ],
 )
 @patch("index_etfs.holdings.get_etf_holdings")
-def test_individual_etf_functions(
-    mock_get_holdings: MagicMock, func: callable, expected_symbol: str
-) -> None:
-    """🧪 Test that individual ETF functions call get_etf_holdings correctly."""
+def test_individual_etf_functions(mock_get_holdings: MagicMock, func: object, expected_symbol: str) -> None:
     mock_get_holdings.return_value = pl.DataFrame()
 
     func()
@@ -401,121 +213,9 @@ def test_individual_etf_functions(
     mock_get_holdings.assert_called_once_with(expected_symbol)
 
 
-# 🔧 Edge case tests
-
-
-def test_filter_and_clean_handles_empty_dataframe() -> None:
-    """🧪 Test that filter_and_clean handles empty DataFrames gracefully."""
-    empty_df = pl.DataFrame(
-        {
-            "Ticker": [],
-            "Name": [],
-            "Weight": [],
-            "Local Currency": [],
-        }
-    )
-
-    result = filter_and_clean(empty_df, "ssga")
-
-    assert len(result) == 0
-    assert set(result.columns) == {"Ticker"}  # Only returns Ticker column
-
-
-def test_save_holdings_creates_directory_if_not_exists(
-    sample_ssga_data: pl.DataFrame, tmp_path: Path
-) -> None:
-    """🧪 Test that save_holdings creates output directory if it doesn't exist."""
-    output_dir = tmp_path / "nested" / "output" / "dir"
-    assert not output_dir.exists()
-
-    df = filter_and_clean(sample_ssga_data, "ssga")
-    save_holdings(df, "test", output_dir)
-
-    assert output_dir.exists()
-    assert (output_dir / "tickers" / "test.txt").exists()
-
-
-def test_get_etf_holdings_handles_case_insensitive_symbols() -> None:
-    """🧪 Test that get_etf_holdings handles uppercase symbols."""
-    with patch("index_etfs.holdings.load_holdings") as mock_load, patch(
-        "index_etfs.holdings.filter_and_clean"
-    ) as mock_filter, patch("index_etfs.holdings.save_holdings"):
-        mock_df = pl.DataFrame({"Ticker": ["AAPL"], "Name": ["Apple"], "Weight": [7.5]})
-        mock_load.return_value = mock_df
-        mock_filter.return_value = mock_df
-
-        # 🔤 Should work with uppercase
-        with patch("index_etfs.holdings.validate_count"):
-            result = get_etf_holdings("SPY")
-
-        assert isinstance(result, pl.DataFrame)
-        mock_load.assert_called_once_with(catalog.ETF_CONFIGS["spy"])
-
-
-def test_get_etf_holdings_raises_on_unknown_provider(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """🧪 Test that bad provider config fails closed."""
-    monkeypatch.setitem(
-        catalog.ETF_CONFIGS,
-        "bad",
-        catalog.ETFConfig(
-            url="http://example.com/data",
-            provider="bad",  # type: ignore[arg-type]
-            watchlist_name="bad",
-            expected_count=1,
-        ),
-    )
-
-    with pytest.raises(ValueError, match="Unknown provider"):
-        get_etf_holdings("bad")  # type: ignore[arg-type]
-
-
-def test_validate_count_rejects_empty_and_tiny_results() -> None:
-    """🧪 Test source count validation."""
-    with pytest.raises(ValueError, match="zero rows"):
-        validate_count("spy", 0)
-
-    with pytest.raises(ValueError, match="expected at least"):
-        validate_count("iwm", 1799)
-
-    validate_count("iwm", 1800)
-
-
-@patch("index_etfs.holdings.load_holdings")
-@patch("index_etfs.holdings.save_holdings")
-def test_get_etf_holdings_validates_before_saving(
-    mock_save: MagicMock, mock_load: MagicMock
-) -> None:
-    """🧪 Test bad counts fail before files are written."""
-    mock_load.return_value = pl.DataFrame(
-        {"Ticker": [], "Local Currency": [], "Name": [], "Weight": []}
-    )
-
-    with pytest.raises(ValueError, match="zero rows"):
-        get_etf_holdings("spy")
-
-    mock_save.assert_not_called()
-
-
-def test_write_metadata_creates_latest_json(tmp_path: Path) -> None:
-    """🧪 Test metadata output shape."""
-    write_metadata({"spy": 503, "qqq": 101}, tmp_path)
-
-    metadata = json.loads((tmp_path / "metadata" / "latest.json").read_text())
-
-    assert metadata["generated_at"].endswith("Z")
-    assert metadata["watchlists"]["sp500"]["count"] == 503
-    assert metadata["watchlists"]["nasdaq100"]["source"] == "qqq"
-    assert "source_url" in metadata["watchlists"]["sp500"]
-
-
 @patch("index_etfs.holdings.write_metadata")
 @patch("index_etfs.holdings.get_etf_holdings")
-def test_main_downloads_all_configured_etfs(
-    mock_get_holdings: MagicMock, mock_write_metadata: MagicMock
-) -> None:
-    """🧪 Test CLI entry point processes every configured ETF."""
+def test_main_downloads_all_configured_etfs(mock_get_holdings: MagicMock, mock_write_metadata: MagicMock) -> None:
     mock_get_holdings.side_effect = [
         pl.DataFrame({"Ticker": range(config.expected_count)})
         for config in catalog.ETF_CONFIGS.values()

--- a/tests/test_holdings.py
+++ b/tests/test_holdings.py
@@ -8,25 +8,30 @@ from unittest.mock import MagicMock, patch
 import polars as pl
 import pytest
 
+import index_etfs.catalog as catalog
 import index_etfs.holdings as holdings
+from index_etfs.catalog import validate_count
 from index_etfs.holdings import (
-    FIREFOX_HEADERS,
-    _filter_and_clean,
-    _tradingview_symbols,
-    _validate_count,
-    _watchlist_lines,
-    _write_metadata,
-    _load_ishares_csv,
-    _load_nasdaq_json,
-    _load_ssga_excel,
-    _read_url,
-    _save_holdings,
     get_etf_holdings,
     get_iwm_holdings,
     get_mdy_holdings,
     get_qqq_holdings,
     get_spsm_holdings,
     get_spy_holdings,
+)
+from index_etfs.outputs import (
+    save_holdings,
+    tradingview_symbols,
+    watchlist_lines,
+    write_metadata,
+)
+from index_etfs.sources import (
+    FIREFOX_HEADERS,
+    filter_and_clean,
+    load_ishares_csv,
+    load_nasdaq_json,
+    load_ssga_excel,
+    read_url,
 )
 
 
@@ -71,7 +76,7 @@ def temp_output_dir(tmp_path: Path) -> Path:
     return tmp_path / "holdings_output"
 
 
-# 🧹 Tests for _filter_and_clean
+# 🧹 Tests for filter_and_clean
 
 
 @pytest.mark.parametrize(
@@ -97,7 +102,7 @@ def test_filter_and_clean(
     else:
         data = sample_nasdaq_data
 
-    result = _filter_and_clean(data, provider)
+    result = filter_and_clean(data, provider)
 
     assert len(result) == expected_len
     assert set(result.columns) == {"Ticker"}
@@ -108,27 +113,27 @@ def test_filter_and_clean(
 
 def test_filter_and_clean_removes_dash_tickers(sample_ssga_data: pl.DataFrame) -> None:
     """🧪 Test that dash tickers are filtered out."""
-    result = _filter_and_clean(sample_ssga_data, "ssga")
+    result = filter_and_clean(sample_ssga_data, "ssga")
     assert "-" not in result["Ticker"].to_list()
 
 
 def test_filter_and_clean_keeps_only_usd(sample_ssga_data: pl.DataFrame) -> None:
     """🧪 Test that only USD currencies are kept for SSGA."""
-    result = _filter_and_clean(sample_ssga_data, "ssga")
+    result = filter_and_clean(sample_ssga_data, "ssga")
     # 💰 Should only have USD tickers (NVDA has EUR so should be filtered)
     assert len(result) == 3
     assert all(ticker in ["AAPL", "MSFT", "GOOGL"] for ticker in result["Ticker"])
 
 
-# 💾 Tests for _save_holdings
+# 💾 Tests for save_holdings
 
 
 def test_save_holdings_creates_txt_file(
     sample_ssga_data: pl.DataFrame, temp_output_dir: Path
 ) -> None:
     """🧪 Test that save_holdings creates a ticker text file."""
-    df = _filter_and_clean(sample_ssga_data, "ssga")
-    _save_holdings(df, "test", temp_output_dir)
+    df = filter_and_clean(sample_ssga_data, "ssga")
+    save_holdings(df, "test", temp_output_dir)
 
     assert (temp_output_dir / "tickers" / "test.txt").exists()
 
@@ -137,8 +142,8 @@ def test_save_holdings_writes_sorted_tickers_with_trailing_newline(
     sample_ssga_data: pl.DataFrame, temp_output_dir: Path
 ) -> None:
     """🧪 Test ticker text output shape."""
-    df = _filter_and_clean(sample_ssga_data, "ssga")
-    _save_holdings(df, "test", temp_output_dir)
+    df = filter_and_clean(sample_ssga_data, "ssga")
+    save_holdings(df, "test", temp_output_dir)
 
     assert (temp_output_dir / "tickers" / "test.txt").read_text() == "AAPL\nGOOGL\nMSFT\n"
 
@@ -148,13 +153,13 @@ def test_save_holdings_defaults_to_cwd(
 ) -> None:
     """🧪 Test that save_holdings uses current directory when no output_dir given."""
     monkeypatch.chdir(tmp_path)
-    df = _filter_and_clean(sample_ssga_data, "ssga")
-    _save_holdings(df, "test")
+    df = filter_and_clean(sample_ssga_data, "ssga")
+    save_holdings(df, "test")
 
     assert (tmp_path / "tickers" / "test.txt").exists()
 
 
-@patch("index_etfs.holdings._tradingview_symbols")
+@patch("index_etfs.outputs.tradingview_symbols")
 def test_save_holdings_writes_tradingview_watchlist(
     mock_symbols: MagicMock, sample_ssga_data: pl.DataFrame, temp_output_dir: Path
 ) -> None:
@@ -164,9 +169,9 @@ def test_save_holdings_writes_tradingview_watchlist(
         "GOOGL": ("NASDAQ:GOOGL", "Communication"),
         "MSFT": ("NASDAQ:MSFT", "Technology"),
     }
-    df = _filter_and_clean(sample_ssga_data, "ssga")
+    df = filter_and_clean(sample_ssga_data, "ssga")
 
-    _save_holdings(df, "spy", temp_output_dir)
+    save_holdings(df, "spy", temp_output_dir)
 
     assert (temp_output_dir / "watchlists" / "sp500.txt").read_text() == (
         "###Communication\nNASDAQ:GOOGL\n###Technology\nNASDAQ:AAPL\nNASDAQ:MSFT\n"
@@ -176,8 +181,8 @@ def test_save_holdings_writes_tradingview_watchlist(
 # 🏢 Tests for loader functions
 
 
-@patch("index_etfs.holdings._read_url", return_value=io.BytesIO())
-@patch("index_etfs.holdings.pl.read_excel")
+@patch("index_etfs.sources.read_url", return_value=io.BytesIO())
+@patch("index_etfs.sources.pl.read_excel")
 def test_load_ssga_excel_handles_dict_response(
     mock_read_excel: MagicMock, _mock_read_url: MagicMock
 ) -> None:
@@ -185,14 +190,14 @@ def test_load_ssga_excel_handles_dict_response(
     mock_df = pl.DataFrame({"Ticker": ["AAPL"], "Weight": [7.5]})
     mock_read_excel.return_value = {"Sheet1": mock_df}
 
-    result = _load_ssga_excel("http://example.com/data.xlsx")
+    result = load_ssga_excel("http://example.com/data.xlsx")
 
     assert isinstance(result, pl.DataFrame)
     assert result.equals(mock_df)
 
 
-@patch("index_etfs.holdings._read_url", return_value=io.BytesIO())
-@patch("index_etfs.holdings.pl.read_excel")
+@patch("index_etfs.sources.read_url", return_value=io.BytesIO())
+@patch("index_etfs.sources.pl.read_excel")
 def test_load_ssga_excel_handles_dataframe_response(
     mock_read_excel: MagicMock, _mock_read_url: MagicMock
 ) -> None:
@@ -200,14 +205,14 @@ def test_load_ssga_excel_handles_dataframe_response(
     mock_df = pl.DataFrame({"Ticker": ["AAPL"], "Weight": [7.5]})
     mock_read_excel.return_value = mock_df
 
-    result = _load_ssga_excel("http://example.com/data.xlsx")
+    result = load_ssga_excel("http://example.com/data.xlsx")
 
     assert isinstance(result, pl.DataFrame)
     assert result.equals(mock_df)
 
 
-@patch("index_etfs.holdings._read_url", return_value=io.BytesIO())
-@patch("index_etfs.holdings.pl.read_csv")
+@patch("index_etfs.sources.read_url", return_value=io.BytesIO())
+@patch("index_etfs.sources.pl.read_csv")
 def test_load_ishares_csv_renames_weight_column(
     mock_read_csv: MagicMock, _mock_read_url: MagicMock
 ) -> None:
@@ -222,60 +227,60 @@ def test_load_ishares_csv_renames_weight_column(
     )
     mock_read_csv.return_value = mock_df
 
-    result = _load_ishares_csv("http://example.com/data.csv")
+    result = load_ishares_csv("http://example.com/data.csv")
 
     assert "Weight" in result.columns
     assert "Weight (%)" not in result.columns
 
 
 @patch(
-    "index_etfs.holdings._read_url",
+    "index_etfs.sources.read_url",
     return_value=io.BytesIO(
         b'{"data":{"data":{"rows":[{"symbol":"AAPL"},{"symbol":"BRK/B"}]}}}'
     ),
 )
 def test_load_nasdaq_json_returns_tickers(_mock_read_url: MagicMock) -> None:
     """🧪 Test loading Nasdaq-100 JSON."""
-    result = _load_nasdaq_json("http://example.com/data.json")
+    result = load_nasdaq_json("http://example.com/data.json")
 
     assert result["Ticker"].to_list() == ["AAPL", "BRK.B"]
 
 
-@patch("index_etfs.holdings._read_url", return_value=io.BytesIO(b'{"data":{}}'))
+@patch("index_etfs.sources.read_url", return_value=io.BytesIO(b'{"data":{}}'))
 def test_load_nasdaq_json_raises_on_missing_rows(_mock_read_url: MagicMock) -> None:
     """🧪 Test Nasdaq JSON fails closed on bad payloads."""
     with pytest.raises(ValueError, match="Nasdaq response"):
-        _load_nasdaq_json("http://example.com/data.json")
+        load_nasdaq_json("http://example.com/data.json")
 
 
 @patch(
-    "index_etfs.holdings._read_url",
+    "index_etfs.sources.read_url",
     return_value=io.BytesIO(b'{"data":{"data":{"rows":[{}]}}}'),
 )
 def test_load_nasdaq_json_raises_on_missing_symbols(_mock_read_url: MagicMock) -> None:
     """🧪 Test Nasdaq JSON fails closed when rows have no symbols."""
     with pytest.raises(ValueError, match="symbols"):
-        _load_nasdaq_json("http://example.com/data.json")
+        load_nasdaq_json("http://example.com/data.json")
 
 
-@patch("index_etfs.holdings.urllib.request.urlopen", return_value=io.BytesIO(b"ok"))
+@patch("index_etfs.sources.urllib.request.urlopen", return_value=io.BytesIO(b"ok"))
 def test_read_url_uses_firefox_headers(mock_urlopen: MagicMock) -> None:
     """🧪 Test URL reads use browser-ish headers."""
-    assert _read_url("http://example.com/data.csv").read() == b"ok"
+    assert read_url("http://example.com/data.csv").read() == b"ok"
 
     request = mock_urlopen.call_args.args[0]
     assert request.get_header("User-agent") == FIREFOX_HEADERS["User-Agent"]
 
 
 @patch(
-    "index_etfs.holdings.urllib.request.urlopen",
+    "index_etfs.sources.urllib.request.urlopen",
     return_value=io.BytesIO(
         b'{"data":[{"s":"NASDAQ:AAPL","d":["AAPL","Technology Services","Consumer Electronics"]}]}'
     ),
 )
 def test_tradingview_symbols_maps_symbols_and_groups(mock_urlopen: MagicMock) -> None:
     """🧪 Test TradingView scanner metadata mapping."""
-    assert _tradingview_symbols(["AAPL"]) == {"AAPL": ("NASDAQ:AAPL", "Technology Services")}
+    assert tradingview_symbols(["AAPL"]) == {"AAPL": ("NASDAQ:AAPL", "Technology Services")}
 
     request = mock_urlopen.call_args.args[0]
     assert request.get_header("Content-type") == "application/json"
@@ -284,7 +289,7 @@ def test_tradingview_symbols_maps_symbols_and_groups(mock_urlopen: MagicMock) ->
 
 def test_watchlist_lines_groups_by_header() -> None:
     """🧪 Test TradingView ### section output."""
-    assert _watchlist_lines(
+    assert watchlist_lines(
         ["AAPL", "MSFT", "BRK.B"],
         {
             "AAPL": ("NASDAQ:AAPL", "Technology"),
@@ -303,72 +308,33 @@ def test_get_etf_holdings_raises_on_unknown_symbol() -> None:
 
 
 
-@patch("index_etfs.holdings._load_ssga_excel")
-@patch("index_etfs.holdings._filter_and_clean")
-@patch("index_etfs.holdings._save_holdings")
-def test_get_etf_holdings_calls_correct_loader_for_ssga(
+@pytest.mark.parametrize("symbol", ["spy", "iwm", "qqq"])
+@patch("index_etfs.holdings.load_holdings")
+@patch("index_etfs.holdings.filter_and_clean")
+@patch("index_etfs.holdings.save_holdings")
+def test_get_etf_holdings_uses_configured_source(
     mock_save: MagicMock,
     mock_filter: MagicMock,
     mock_load: MagicMock,
+    symbol: str,
     sample_ssga_data: pl.DataFrame,
 ) -> None:
-    """🧪 Test that SSGA ETFs use the correct loader."""
+    """🧪 Test that configured ETFs load, clean, and save."""
+    config = catalog.ETF_CONFIGS[symbol]
     mock_load.return_value = sample_ssga_data
     mock_filter.return_value = sample_ssga_data
 
-    with patch("index_etfs.holdings._validate_count"):
-        get_etf_holdings("spy")
+    with patch("index_etfs.holdings.validate_count"):
+        get_etf_holdings(symbol)
 
-    mock_load.assert_called_once()
-    mock_filter.assert_called_once_with(sample_ssga_data, "ssga")
+    mock_load.assert_called_once_with(config)
+    mock_filter.assert_called_once_with(sample_ssga_data, config.provider)
     mock_save.assert_called_once()
 
 
-@patch("index_etfs.holdings._load_ishares_csv")
-@patch("index_etfs.holdings._filter_and_clean")
-@patch("index_etfs.holdings._save_holdings")
-def test_get_etf_holdings_calls_correct_loader_for_ishares(
-    mock_save: MagicMock,
-    mock_filter: MagicMock,
-    mock_load: MagicMock,
-    sample_ishares_data: pl.DataFrame,
-) -> None:
-    """🧪 Test that iShares ETFs use the correct loader."""
-    mock_load.return_value = sample_ishares_data
-    mock_filter.return_value = sample_ishares_data
-
-    with patch("index_etfs.holdings._validate_count"):
-        get_etf_holdings("iwm")
-
-    mock_load.assert_called_once()
-    mock_filter.assert_called_once_with(sample_ishares_data, "ishares")
-    mock_save.assert_called_once()
-
-
-@patch("index_etfs.holdings._load_nasdaq_json")
-@patch("index_etfs.holdings._filter_and_clean")
-@patch("index_etfs.holdings._save_holdings")
-def test_get_etf_holdings_calls_correct_loader_for_nasdaq(
-    mock_save: MagicMock,
-    mock_filter: MagicMock,
-    mock_load: MagicMock,
-    sample_nasdaq_data: pl.DataFrame,
-) -> None:
-    """🧪 Test that Nasdaq-100 uses the correct loader."""
-    mock_load.return_value = sample_nasdaq_data
-    mock_filter.return_value = sample_nasdaq_data
-
-    with patch("index_etfs.holdings._validate_count"):
-        get_etf_holdings("qqq")
-
-    mock_load.assert_called_once()
-    mock_filter.assert_called_once_with(sample_nasdaq_data, "nasdaq")
-    mock_save.assert_called_once()
-
-
-@patch("index_etfs.holdings._load_ssga_excel")
-@patch("index_etfs.holdings._filter_and_clean")
-@patch("index_etfs.holdings._save_holdings")
+@patch("index_etfs.holdings.load_holdings")
+@patch("index_etfs.holdings.filter_and_clean")
+@patch("index_etfs.holdings.save_holdings")
 def test_get_etf_holdings_passes_output_dir(
     mock_save: MagicMock,
     mock_filter: MagicMock,
@@ -380,7 +346,7 @@ def test_get_etf_holdings_passes_output_dir(
     mock_load.return_value = sample_ssga_data
     mock_filter.return_value = sample_ssga_data
 
-    with patch("index_etfs.holdings._validate_count"):
+    with patch("index_etfs.holdings.validate_count"):
         get_etf_holdings("spy", output_dir=temp_output_dir)
 
     mock_save.assert_called_once()
@@ -389,9 +355,9 @@ def test_get_etf_holdings_passes_output_dir(
     assert call_args[0][2] == temp_output_dir  # output_dir
 
 
-@patch("index_etfs.holdings._load_ssga_excel")
-@patch("index_etfs.holdings._filter_and_clean")
-@patch("index_etfs.holdings._save_holdings")
+@patch("index_etfs.holdings.load_holdings")
+@patch("index_etfs.holdings.filter_and_clean")
+@patch("index_etfs.holdings.save_holdings")
 def test_get_etf_holdings_returns_dataframe(
     mock_save: MagicMock,
     mock_filter: MagicMock,
@@ -400,10 +366,10 @@ def test_get_etf_holdings_returns_dataframe(
 ) -> None:
     """🧪 Test that get_etf_holdings returns a DataFrame."""
     mock_load.return_value = sample_ssga_data
-    cleaned_df = _filter_and_clean(sample_ssga_data, "ssga")
+    cleaned_df = filter_and_clean(sample_ssga_data, "ssga")
     mock_filter.return_value = cleaned_df
 
-    with patch("index_etfs.holdings._validate_count"):
+    with patch("index_etfs.holdings.validate_count"):
         result = get_etf_holdings("spy")
 
     assert isinstance(result, pl.DataFrame)
@@ -449,7 +415,7 @@ def test_filter_and_clean_handles_empty_dataframe() -> None:
         }
     )
 
-    result = _filter_and_clean(empty_df, "ssga")
+    result = filter_and_clean(empty_df, "ssga")
 
     assert len(result) == 0
     assert set(result.columns) == {"Ticker"}  # Only returns Ticker column
@@ -462,8 +428,8 @@ def test_save_holdings_creates_directory_if_not_exists(
     output_dir = tmp_path / "nested" / "output" / "dir"
     assert not output_dir.exists()
 
-    df = _filter_and_clean(sample_ssga_data, "ssga")
-    _save_holdings(df, "test", output_dir)
+    df = filter_and_clean(sample_ssga_data, "ssga")
+    save_holdings(df, "test", output_dir)
 
     assert output_dir.exists()
     assert (output_dir / "tickers" / "test.txt").exists()
@@ -471,19 +437,19 @@ def test_save_holdings_creates_directory_if_not_exists(
 
 def test_get_etf_holdings_handles_case_insensitive_symbols() -> None:
     """🧪 Test that get_etf_holdings handles uppercase symbols."""
-    with patch("index_etfs.holdings._load_ssga_excel") as mock_load, patch(
-        "index_etfs.holdings._filter_and_clean"
-    ) as mock_filter, patch("index_etfs.holdings._save_holdings"):
+    with patch("index_etfs.holdings.load_holdings") as mock_load, patch(
+        "index_etfs.holdings.filter_and_clean"
+    ) as mock_filter, patch("index_etfs.holdings.save_holdings"):
         mock_df = pl.DataFrame({"Ticker": ["AAPL"], "Name": ["Apple"], "Weight": [7.5]})
         mock_load.return_value = mock_df
         mock_filter.return_value = mock_df
 
         # 🔤 Should work with uppercase
-        with patch("index_etfs.holdings._validate_count"):
-            result = get_etf_holdings("SPY")  # type: ignore[arg-type]
+        with patch("index_etfs.holdings.validate_count"):
+            result = get_etf_holdings("SPY")
 
         assert isinstance(result, pl.DataFrame)
-        mock_load.assert_called_once()
+        mock_load.assert_called_once_with(catalog.ETF_CONFIGS["spy"])
 
 
 def test_get_etf_holdings_raises_on_unknown_provider(
@@ -491,9 +457,9 @@ def test_get_etf_holdings_raises_on_unknown_provider(
 ) -> None:
     """🧪 Test that bad provider config fails closed."""
     monkeypatch.setitem(
-        holdings.ETF_CONFIGS,
+        catalog.ETF_CONFIGS,
         "bad",
-        holdings.ETFConfig(
+        catalog.ETFConfig(
             url="http://example.com/data",
             provider="bad",  # type: ignore[arg-type]
             watchlist_name="bad",
@@ -508,16 +474,16 @@ def test_get_etf_holdings_raises_on_unknown_provider(
 def test_validate_count_rejects_empty_and_tiny_results() -> None:
     """🧪 Test source count validation."""
     with pytest.raises(ValueError, match="zero rows"):
-        _validate_count("spy", 0)
+        validate_count("spy", 0)
 
     with pytest.raises(ValueError, match="expected at least"):
-        _validate_count("iwm", 1799)
+        validate_count("iwm", 1799)
 
-    _validate_count("iwm", 1800)
+    validate_count("iwm", 1800)
 
 
-@patch("index_etfs.holdings._load_ssga_excel")
-@patch("index_etfs.holdings._save_holdings")
+@patch("index_etfs.holdings.load_holdings")
+@patch("index_etfs.holdings.save_holdings")
 def test_get_etf_holdings_validates_before_saving(
     mock_save: MagicMock, mock_load: MagicMock
 ) -> None:
@@ -534,7 +500,7 @@ def test_get_etf_holdings_validates_before_saving(
 
 def test_write_metadata_creates_latest_json(tmp_path: Path) -> None:
     """🧪 Test metadata output shape."""
-    _write_metadata({"spy": 503, "qqq": 101}, tmp_path)
+    write_metadata({"spy": 503, "qqq": 101}, tmp_path)
 
     metadata = json.loads((tmp_path / "metadata" / "latest.json").read_text())
 
@@ -544,7 +510,7 @@ def test_write_metadata_creates_latest_json(tmp_path: Path) -> None:
     assert "source_url" in metadata["watchlists"]["sp500"]
 
 
-@patch("index_etfs.holdings._write_metadata")
+@patch("index_etfs.holdings.write_metadata")
 @patch("index_etfs.holdings.get_etf_holdings")
 def test_main_downloads_all_configured_etfs(
     mock_get_holdings: MagicMock, mock_write_metadata: MagicMock
@@ -552,10 +518,10 @@ def test_main_downloads_all_configured_etfs(
     """🧪 Test CLI entry point processes every configured ETF."""
     mock_get_holdings.side_effect = [
         pl.DataFrame({"Ticker": range(config.expected_count)})
-        for config in holdings.ETF_CONFIGS.values()
+        for config in catalog.ETF_CONFIGS.values()
     ]
 
     holdings.main()
 
-    assert mock_get_holdings.call_count == len(holdings.ETF_CONFIGS)
+    assert mock_get_holdings.call_count == len(catalog.ETF_CONFIGS)
     mock_write_metadata.assert_called_once()

--- a/tests/test_holdings.py
+++ b/tests/test_holdings.py
@@ -493,7 +493,12 @@ def test_get_etf_holdings_raises_on_unknown_provider(
     monkeypatch.setitem(
         holdings.ETF_CONFIGS,
         "bad",
-        {"url": "http://example.com/data", "provider": "bad"},
+        holdings.ETFConfig(
+            url="http://example.com/data",
+            provider="bad",  # type: ignore[arg-type]
+            watchlist_name="bad",
+            expected_count=1,
+        ),
     )
 
     with pytest.raises(ValueError, match="Unknown provider"):
@@ -546,8 +551,8 @@ def test_main_downloads_all_configured_etfs(
 ) -> None:
     """🧪 Test CLI entry point processes every configured ETF."""
     mock_get_holdings.side_effect = [
-        pl.DataFrame({"Ticker": range(holdings.EXPECTED_COUNTS[symbol])})
-        for symbol in holdings.ETF_CONFIGS
+        pl.DataFrame({"Ticker": range(config.expected_count)})
+        for config in holdings.ETF_CONFIGS.values()
     ]
 
     holdings.main()


### PR DESCRIPTION
## What changed

- Groups ETF URL/provider/watchlist/count settings in one config object.
- Splits source loading, output writing, and public orchestration into small modules.
- Reworks tests around public behavior with network calls mocked at the boundary.

## Checks

- `uv run ruff check .`
- `uv run pytest`

## Notes

CodeRabbit local review was skipped because the quota reset was more than 10 minutes away.
