### PR TITLE
refactor: simplify holdings output flow

### DIFF
--- a/src/index_etfs/holdings.py
+++ b/src/index_etfs/holdings.py
@@ -29,31 +29,6 @@ def get_etf_holdings(
     return df
 
 
-def get_spy_holdings() -> pl.DataFrame:
-    """📊 Get ticker symbols from the SPY ETF."""
-    return get_etf_holdings("spy")
-
-
-def get_mdy_holdings() -> pl.DataFrame:
-    """📊 Get ticker symbols from the MDY ETF."""
-    return get_etf_holdings("mdy")
-
-
-def get_spsm_holdings() -> pl.DataFrame:
-    """📊 Get ticker symbols from the SPSM ETF."""
-    return get_etf_holdings("spsm")
-
-
-def get_qqq_holdings() -> pl.DataFrame:
-    """📊 Get ticker symbols from the Nasdaq-100."""
-    return get_etf_holdings("qqq")
-
-
-def get_iwm_holdings() -> pl.DataFrame:
-    """📊 Get ticker symbols from the IWM ETF."""
-    return get_etf_holdings("iwm")
-
-
 def main() -> None:
     """🚀 Download all ETF holdings."""
     print("📥 Downloading ETF holdings...")

--- a/src/index_etfs/outputs.py
+++ b/src/index_etfs/outputs.py
@@ -93,28 +93,30 @@ def watchlist_lines(tickers: list[str], symbols: dict[str, tuple[str, str]]) -> 
     return [line for group in sorted(groups) for line in (f"###{group}", *groups[group])]
 
 
+def _write_lines(path: Path, lines: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n")
+
+
+def _save_watchlist(tickers: list[str], watchlist_name: str, output_dir: Path) -> None:
+    symbols = tradingview_symbols(tickers)
+    missing = [ticker for ticker in tickers if ticker not in symbols]
+    if missing:
+        print(f"⚠️  No TradingView metadata for {', '.join(missing)}")
+
+    _write_lines(
+        output_dir / "watchlists" / f"{watchlist_name}.txt",
+        watchlist_lines(tickers, symbols),
+    )
+
+
 def save_holdings(df: pl.DataFrame, symbol: str, output_dir: Path | None = None) -> None:
     """Save ticker symbols and TradingView watchlists."""
     if output_dir is None:
         output_dir = Path.cwd()
 
-    output_dir.mkdir(parents=True, exist_ok=True)
-
     tickers = df["Ticker"].to_list()
-    tickers_dir = output_dir / "tickers"
-    tickers_dir.mkdir(exist_ok=True)
-    (tickers_dir / f"{symbol}.txt").write_text("\n".join(tickers) + "\n")
+    _write_lines(output_dir / "tickers" / f"{symbol}.txt", tickers)
 
-    config = ETF_CONFIGS.get(symbol)
-    if config is None:
-        return
-
-    watchlist_dir = output_dir / "watchlists"
-    watchlist_dir.mkdir(exist_ok=True)
-    symbols = tradingview_symbols(tickers)
-    missing = [ticker for ticker in tickers if ticker not in symbols]
-    if missing:
-        print(f"⚠️  No TradingView metadata for {', '.join(missing)}")
-    (watchlist_dir / f"{config.watchlist_name}.txt").write_text(
-        "\n".join(watchlist_lines(tickers, symbols)) + "\n"
-    )
+    if config := ETF_CONFIGS.get(symbol):
+        _save_watchlist(tickers, config.watchlist_name, output_dir)

--- a/src/index_etfs/outputs.py
+++ b/src/index_etfs/outputs.py
@@ -42,31 +42,37 @@ def write_metadata(results: dict[str, int], output_dir: Path | None = None) -> N
     (metadata_dir / "latest.json").write_text(json.dumps(metadata, indent=2) + "\n")
 
 
+def _scan_tradingview(tickers: list[str]) -> list[dict]:
+    """Fetch one TradingView scanner page."""
+    payload = {
+        "filter": [{"left": "name", "operation": "in_range", "right": tickers}],
+        "columns": ["name", "sector", "industry"],
+        "markets": ["america"],
+    }
+    request = urllib.request.Request(
+        TRADINGVIEW_SCAN_URL,
+        data=json.dumps(payload).encode(),
+        headers=FIREFOX_HEADERS
+        | {
+            "Content-Type": "application/json",
+            "Origin": "https://www.tradingview.com",
+            "Referer": "https://www.tradingview.com/",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.load(response).get("data", [])
+
+
 def tradingview_symbols(tickers: list[str], chunk_size: int = 200) -> dict[str, tuple[str, str]]:
     """Map tickers to TradingView symbols and sector-ish group names."""
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be positive")
+
     symbols = {}
-    headers = FIREFOX_HEADERS | {
-        "Content-Type": "application/json",
-        "Origin": "https://www.tradingview.com",
-        "Referer": "https://www.tradingview.com/",
-    }
 
     for start in range(0, len(tickers), chunk_size):
         chunk = tickers[start : start + chunk_size]
-        payload = {
-            "filter": [{"left": "name", "operation": "in_range", "right": chunk}],
-            "columns": ["name", "sector", "industry"],
-            "markets": ["america"],
-        }
-        request = urllib.request.Request(
-            TRADINGVIEW_SCAN_URL,
-            data=json.dumps(payload).encode(),
-            headers=headers,
-        )
-        with urllib.request.urlopen(request, timeout=30) as response:
-            rows = json.load(response).get("data", [])
-
-        for row in rows:
+        for row in _scan_tradingview(chunk):
             data = row.get("d", [])
             ticker = data[0] if data else None
             symbol = row.get("s", "")

--- a/tests/test_holdings.py
+++ b/tests/test_holdings.py
@@ -141,6 +141,11 @@ def test_tradingview_symbols(mock_urlopen: MagicMock) -> None:
     assert json.loads(request.data)["columns"] == ["name", "sector", "industry"]
 
 
+def test_tradingview_symbols_rejects_invalid_chunk_size() -> None:
+    with pytest.raises(ValueError, match="chunk_size"):
+        tradingview_symbols(["AAPL"], chunk_size=0)
+
+
 def test_watchlist_lines_groups_by_header() -> None:
     assert watchlist_lines(
         ["AAPL", "MSFT", "BRK.B"],

--- a/tests/test_holdings.py
+++ b/tests/test_holdings.py
@@ -11,14 +11,7 @@ import pytest
 import index_etfs.catalog as catalog
 import index_etfs.holdings as holdings
 from index_etfs.catalog import ETFConfig, validate_count
-from index_etfs.holdings import (
-    get_etf_holdings,
-    get_iwm_holdings,
-    get_mdy_holdings,
-    get_qqq_holdings,
-    get_spsm_holdings,
-    get_spy_holdings,
-)
+from index_etfs.holdings import get_etf_holdings
 from index_etfs.outputs import save_holdings, tradingview_symbols, watchlist_lines, write_metadata
 from index_etfs.sources import (
     FIREFOX_HEADERS,
@@ -197,25 +190,6 @@ def test_validate_count_rejects_empty_and_tiny_results() -> None:
     with pytest.raises(ValueError, match="expected at least"):
         validate_count("iwm", 1799)
     validate_count("iwm", 1800)
-
-
-@pytest.mark.parametrize(
-    ("func", "expected_symbol"),
-    [
-        (get_spy_holdings, "spy"),
-        (get_mdy_holdings, "mdy"),
-        (get_spsm_holdings, "spsm"),
-        (get_qqq_holdings, "qqq"),
-        (get_iwm_holdings, "iwm"),
-    ],
-)
-@patch("index_etfs.holdings.get_etf_holdings")
-def test_individual_etf_functions(mock_get_holdings: MagicMock, func: object, expected_symbol: str) -> None:
-    mock_get_holdings.return_value = pl.DataFrame()
-
-    func()
-
-    mock_get_holdings.assert_called_once_with(expected_symbol)
 
 
 @patch("index_etfs.holdings.write_metadata")


### PR DESCRIPTION
## Summary
- isolate TradingView scanner requests from symbol mapping
- split ticker and watchlist file writes into small helpers
- remove redundant ETF-specific holdings wrappers

## Tests
- `uv run ruff check .`
- `uv run pytest`

## Review notes
- CodeRabbit: fixed the invalid `chunk_size` guard finding.
- Ponytail: no extra cuts without undoing the requested separation.
